### PR TITLE
Release v3.2.1

### DIFF
--- a/_static/emailform.html
+++ b/_static/emailform.html
@@ -12,7 +12,7 @@ var ml_account = ml('accounts', '2470723', 'f5z7y5q2e5', 'load');
 
 <blockquote>
 <div><ul class="simple">
-<li><p><a class="reference download external" href="javascript:;" onclick="ml_account('webforms', '2915332', 't8i0h3', 'show')"><code class="xref download docutils literal notranslate"><span class="pre">CATO</span> <span class="pre">v3.2.0</span> <span class="pre">-</span> <span class="pre">Mac</span> <span class="pre">OS</span> <span class="pre">X</span></code></a></p></li>
-<li><p><a class="reference download external" download="" href="javascript:;" onclick="ml_account('webforms', '2915332', 't8i0h3', 'show')"><code class="xref download docutils literal notranslate"><span class="pre">CATO</span> <span class="pre">v3.2.0</span> <span class="pre">-</span> <span class="pre">UNIX</span></code></a></p></li>
+<li><p><a class="reference download external" href="javascript:;" onclick="ml_account('webforms', '2915332', 't8i0h3', 'show')"><code class="xref download docutils literal notranslate"><span class="pre">CATO</span> <span class="pre">v3.2.1</span> <span class="pre">-</span> <span class="pre">Mac</span> <span class="pre">OS</span> <span class="pre">X</span></code></a></p></li>
+<li><p><a class="reference download external" download="" href="javascript:;" onclick="ml_account('webforms', '2915332', 't8i0h3', 'show')"><code class="xref download docutils literal notranslate"><span class="pre">CATO</span> <span class="pre">v3.2.1</span> <span class="pre">-</span> <span class="pre">UNIX</span></code></a></p></li>
 </ul>
 </div></blockquote>

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -26,6 +26,10 @@ Additional software often used with CATO are described in the :ref:`Installation
 
     Older versions of CATO (binaries and source-code) can be downloaded from `the CATO repository on Github <https://github.com/dutchconnectomelab/CATO/releases>`_ and older versions of this documentation website (corresponding to older CATO versions) can be downloaded from `the CATO docs repository on GitHub <https://github.com/dutchconnectomelab/CATO-docs/releases>`_ .
 
+    - Version 3.2.1 (13 February 2023)
+    	- Fixes fMRI bandpass filter artefacts at the beginning and end of the filtered rs-fMRI time series.
+    	- Full Changelog: https://github.com/dutchconnectomelab/CATO/compare/v3.2.0...v3.2.1
+
     - Version 3.2.0 (30 November 2022)
    	- Introduces a test framework for continuous integration.
 		- Lets users specify the functional connectivity measure (e.g. Pearson correlations or Pearson partial correlations).

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,7 +12,7 @@ Compiled binaries of the latest toolbox version:
 .. raw:: html
 	:file: ../_static/emailform.html
 
-and all source code is available on `the GitHub repository <https://github.com/dutchconnectomelab/CATO/>`_. CATO is also available as Docker image on `Docker Hub <https://hub.docker.com/r/dutchconnectomelab/cato>`_.
+and all source code is available on `the GitHub repository <https://github.com/dutchconnectomelab/CATO/>`_. CATO is also available as Docker image on `Docker Hub <https://hub.docker.com/r/dutchconnectomelab/cato/tags>`_.
 
 Example configuration files can be downloaded (or use the :ref:`online Configuration Assistant <configuration assistant>`):
  


### PR DESCRIPTION
Updated links and change notes for the new CATO version (v3.2.1).